### PR TITLE
fixed rumtime error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,6 @@ FROM alpine:latest
 # Set non-interactive mode to prevent prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Define architecture-based variables
-ARG TARGETARCH
-ARG VERSION
-ENV AGENT_URL=https://github.com/nezhahq/agent/releases/download/${VERSION}/nezha-agent_linux_${TARGETARCH}.zip
-
 # Install necessary dependencies
 RUN apk add --no-cache \
     curl \
@@ -17,8 +12,16 @@ RUN apk add --no-cache \
     ca-certificates \
     uuidgen
 
+# Define architecture-based variables
+ARG TARGETARCH
+ARG VERSION
+ENV AGENT_URL=https://github.com/nezhahq/agent/releases/download/${VERSION}/nezha-agent_linux_${TARGETARCH}.zip
+
 # Create the working directory for Nezha Agent
 RUN mkdir -p /usr/local/bin/nezha && cd /usr/local/bin/nezha
+
+# Set working directory
+WORKDIR /usr/local/bin/nezha/
 
 # Download and extract the Nezha Agent binary
 RUN wget $AGENT_URL -O nezha-agent.zip && \
@@ -30,8 +33,5 @@ RUN wget $AGENT_URL -O nezha-agent.zip && \
 COPY setup-config.sh /usr/local/bin/nezha/setup-config.sh
 RUN chmod +x /usr/local/bin/nezha/setup-config.sh
 
-# Set working directory
-WORKDIR /usr/local/bin/nezha
-
 # Set default command to execute the setup script and start the agent
-CMD ["./setup-config.sh", "&&", "./nezha-agent", "-c", "config.yml"]
+CMD ["sh", "-c", "./setup-config.sh && ./nezha-agent -c config.yml"]

--- a/setup-config.sh
+++ b/setup-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Default values or skip setting if not provided
 CLIENT_SECRET=${CLIENT_SECRET:-""}


### PR DESCRIPTION
使用命令
```
docker run --rm \ 
  -e CLIENT_SECRET='0000000000000000000' \
  -e SERVER='000000000000000000000' \
  kanggle/nezha-agent
```
出现错误 `exec ./setup-config.sh: no such file or directory`

该pr做出了以下修改

1. alpine 中没有 bash, 将 setup-config.sh 中的 shebang 改为了 sh
2. 将 apk... 提前，以便 debug 时复用缓存
3. workdir 位置错误，导致 nezha-agent 被解压在 `/`
4. 修改启动时命令